### PR TITLE
Remove a duplicate on Index.json

### DIFF
--- a/index.json
+++ b/index.json
@@ -59,7 +59,6 @@
   "Nice Pottery Mug",
   "Nicely Packaged Make",
   "Nicely Presented Misnomer",
-  "Nicely Presented Misnomer",
   "Nicer Package Manager",
   "Nicer Perusal Method",
   "Niche Portobello Mushroom",


### PR DESCRIPTION
"Nicely Presented Misnomer" appears twice. Edited out the duplicate.
