### PR TITLE
Add No Possible Meaning

### DIFF
--- a/index.json
+++ b/index.json
@@ -86,6 +86,7 @@
   "No Packages Misplaced",
   "No Plugins; Monolithic",
   "No Potty Mouths",
+  "No Possible Meaning",
   "No Prize Money",
   "No Problem Mate",
   "No Problem, Meatbag",


### PR DESCRIPTION
I just gotta add one after reading this [blog post](http://blog.izs.me/post/104685388058/io-js). Why isn't _novel pun-making_ in the list though?
