### PR TITLE
npm is not an acronym

### DIFF
--- a/index.json
+++ b/index.json
@@ -157,6 +157,7 @@
   "Now Printing Money",
   "Now, Please Meander",
   "Now, Publish Me",
+  "npm is not an acronym",
   "npm's pretty magical",
   "NPM: Package Manager",
   "NPM: Possibly Marvellous",


### PR DESCRIPTION
It is [right in the documentation](https://docs.npmjs.com/misc/faq#if-npm-is-an-acronym-why-is-it-never-capitalized-) yet this expansion is missing. How come? :astonished: