### PR TITLE
Naming Prosecution Mitigator

### DIFF
--- a/index.json
+++ b/index.json
@@ -9,6 +9,7 @@
   "Nameless Package Manager",
   "Namely, Pickled Meatballs",
   "Namespace Pollution Mechanism",
+  "Naming Prosecution Mitigator",
   "Nancy's Preferred Machete",
   "Napping Panda Missionaries",
   "Narcoleptic Pasta Manufacturer",


### PR DESCRIPTION
Since npm is not an acronym, what is it? To answer this question, we must ask ourselves, *why* can it not be the acronym most people think it is? If the answer to *that* question is because certain lawyers for a certain company like to throw around a certain four-letter word, then the Naming Prosecution Mitigator is, indeed, a Naming Prosecution Mitigator. The timing and rationale of this commit/pull request should be self-evident.