### PR TITLE
Nucleophosmin

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -359,6 +359,7 @@ Nuclear Powered Macros
 Nuclear Pumpkin Mocha
 Nuclear-Powered Malevolence
 Nuclearly Potent Moonshine
+Nucleophosmin
 nuǝɯ pǝɥsᴉꞁod mǝu
 Nuke Powered Mushroom
 Nukem's Possible Manifestation


### PR DESCRIPTION
It's not *technically* a three-word expansion, but the abbreviation for Nucleophosmin in biology circles is `NPM1`, so it seems like it fits.

https://en.wikipedia.org/wiki/NPM1