### PR TITLE
Nemo's Parental Misguidance

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -121,6 +121,7 @@ Negligible Participation Metric
 Neighbourhood Party Manager
 Neighbor's Preppy Maltese
 Neil Patrick's Mansion
+Nemo's Parental Misguidance
 Neoanthropic Preternatural Murmurings
 Neoclassical Piano Montage
 Neoclassical Programming Multitude


### PR DESCRIPTION
Because... his dad is great and all, but a little overprotective with his advice. Nemo just wanted to explore... wait Nemo probably should have listened to his dad. I'm torn on the issue, but I think the acronym is solid.