### PR TITLE
Natively Packing Megawatts

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -66,6 +66,7 @@ National Public Mania
 Nationwide Polygamous Matrimony
 Native Package Manager
 Native Papuan Masks
+Natively Packing Megawatts
 Natively Pronounced Mandarin
 Nattily Primped Monster
 Natural Pacifist Manatees


### PR DESCRIPTION
Adding the message __Natively Packing Megawatts__ as an over-statement for possession of power