### PR TITLE
Nodal Passel Marshal

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -351,6 +351,7 @@ Nocturnal Parakeet Monitor
 Nocturnal Practitioners of Magic
 Nocturnal Programmer's Machine
 Nocturnally Psychologizing Millipede
+Nodal Passel Marshal
 Node Package Maid
 Node Package Manager
 Node Package Master


### PR DESCRIPTION
3 uniques! Triple word score! :100: 

**[Nodal](http://dictionary.reference.com/browse/nodal
)** - _adjective_
> pertaining to or of the nature of a node

**[Passel](http://dictionary.reference.com/browse/passel)** - _noun_
> a group or lot of indeterminate number 

**[Marshal](http://dictionary.reference.com/browse/marshal)** - _verb_, _noun_
> 1. to arrange in proper order; set out in an orderly manner; arrange clearly:
2. to array, as for battle.
3. to usher or lead ceremoniously:
4. Heraldry. to combine (two or more coats of arms) on a single escutcheon.
