### PR TITLE
Nihil Prius Modulus

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -306,6 +306,7 @@ Nightly Punk Masters
 Nights Pay More
 Nighttime Peanut Migrations
 Nighttime Possum Meandering
+Nihil Prius Modulus
 Nihilist Pocket Monsters
 Nihilist Postmodern Mistake
 Nil Packet Minimizer


### PR DESCRIPTION
Latin for "nothing before (more important than) modules"