### PR TITLE
Fixing missing t in Patchouli

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -137,7 +137,7 @@ Need Pray More
 Need Private Modules
 Need Prize Money
 Needle-Pinpointing Machine
-Needless Pachouli Manufacture
+Needless Patchouli Manufacture
 Needlessly Postulating Minds
 Needlessly Promiscuous, Modularize!
 Needlessly Provoking Marsupials


### PR DESCRIPTION
Patchouli was originally spelled Pachouli, which managed to go unnoticed for a while, though it's spelled correctly in the README. This pull rectifies the issue. 