### PR TITLE
Add "Node's Pastoral Musicians"

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -500,6 +500,7 @@ Node Plus Me
 Node Popular Man
 Node Promiscuous Modules
 Node's Package Magician
+Node's Pastoral Musicians
 Node's Perfect Mate
 Node's Perpetuum Mobile
 Node's Personal Monk


### PR DESCRIPTION
I know this is in the "no more of these" list (unless it's _really good_).

This is a [nod](https://forum.wordreference.com/threads/in-a-nod-to-something.1345678/) to http://npm.org, which belongs to the National Association of Pastoral Musicians.