### PR TITLE
Add an allusion to Python in expansions.txt

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -351,6 +351,7 @@ Next Popular Module
 Next Prince Montage
 next() Packaged Middleware
 NeXTSTEP Programming Mastermind
+Ni! —Python, Monty
 Nibble Plum Meringue
 Nibbling Perfect Macaroni
 Nicaragua's Pet Mice


### PR DESCRIPTION
…since the name of the Python language comes from Monty Python, where the knights say “Ni!”