### PR TITLE
fix build.js filter

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,8 +8,7 @@ var list = fs
   .readFileSync(infile, 'utf8')
   .split("\n")
   .map(function(e) { return e.trim() })
-  .filter(function(e) { return (e.length > 0) })
-  .filter(function(e) { return e.charAt(0).toLowerCase() === "n" })
+  .filter(function(e) { return e.length > 0 && e.charAt(0) !== "#" })
   .sort(function (a, b) {
     return a.toLowerCase().localeCompare(b.toLowerCase());
   })


### PR DESCRIPTION
Some expansions don't start with `n`, like `*nix` and other random things