### PR TITLE
'Nestorians Pranking Monophysites'

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -266,6 +266,7 @@ Nervously Proposing Marriage
 Nestable Processes Mutate
 Nested Parenthetical Madness
 Nested Public Modules
+Nestorians Pranking Monophysites
 Net Possibility Multiplier
 Netherworld's Pretend Minibar
 Neti Pot Manufacturer


### PR DESCRIPTION
> Nestorianism is a Christological doctrine that emphasizes a distinction between the human and divine natures of the divine person, Jesus.

–– from https://en.wikipedia.org/wiki/Nestorianism

> Monophysitism is the Christological position that, after the union of the divine and the human in the historical incarnation, Jesus Christ, as the incarnation of the eternal Son or Word (Logos) of God, had only a single "nature" which was either divine or a synthesis of divine and human.

–– from https://en.wikipedia.org/wiki/Monophysitism