### PR TITLE
Now Protect Mazaalai

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -422,8 +422,8 @@ Nightly Procrastination Machine
 Nightly Punk Masters
 Nightmare Prom Memories
 Nightmarish Pawnshop Mystic
-Nighttime Pachinko Marathon
 Nights Pay More
+Nighttime Pachinko Marathon
 Nighttime Peanut Migrations
 Nighttime Possum Meandering
 Nihil Prius Modulus
@@ -713,6 +713,7 @@ Now Particularly Misnamed
 Now Playing Mario
 Now Playing Mathcore
 Now Printing Money
+Now Protect Mazaalai
 Now with Partition Management
 Now, Please Meander
 Now, Publish Me


### PR DESCRIPTION
The Gobi bear, Ursus arctos gobiensis (known in Mongolian as the mazaalai/Мазаалай), is a subspecies of the brown bear, Ursus arctos, that is found in the Gobi Desert of Mongolia. It is listed as critically endangered by Mongolian Redbook of Endangered Species and by the Zoological Society of London using IUCN standards. The UN backed Convention of Migratory Species selected Gobi bear for protection in 2017.[1] The population included only around 30 adults in 2009[2] and is separated by enough distance from other brown bear populations to achieve reproductive isolation.