### PR TITLE
Remove `Nagging Mario's Princess`

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -12,7 +12,6 @@ Nacho Printing Machine
 Nachos Pillage Milwaukee
 Nachos Preventing Motivation
 Nadie Programa más
-Nagging Mario's Princess
 Nagging Penguin Matriarchs
 Nahi Pata Mujhe!
 Nail Polish Makeover


### PR DESCRIPTION

# What / Why
`Nagging Mario's Princess` is not a valid expansion of NPM and as such, should be removed.

## References
* `Nagging Mario's Princess` = NMP !== NPM
