### PR TITLE
nCoV Postponing Matches

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -151,6 +151,7 @@ Navel Piercing Madness
 Navel Pondering Mantra
 Navy Penguin Mariachi
 Naysayers Promote Misery
+nCoV Postponing Matches
 Ne Pas Manger!
 Neanderthal Painting Monet
 Neanderthal Pudding Mix


### PR DESCRIPTION
https://www.euronews.com/2020/03/17/coronavirus-uefa-moves-euro-2020-to-2021-due-to-covid-19-chaos