### PR TITLE
Newly Partisan Mon Calamari

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -381,6 +381,7 @@ Newfoundland Pitbull Mix
 Newline Pending Merge
 Newline Proliferating Maniac
 Newly Paranoid Maintainers
+Newly Partisan Mon Calamari
 Newly Picked Mangoes
 Newly Potted Mandrakes
 Newly Practicing Mortician


### PR DESCRIPTION
In case you're unfamiliar, Mon Calamari are a species in Star Wars. During the Clone Wars, their home planet (like many planets) became divided by the conflict. https://starwars.fandom.com/wiki/Mon_Calamari

# What / Why
<!-- Describe the request in detail -->
> n/a

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
