### PR TITLE
Noop Prevents Misuse

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -640,6 +640,7 @@ Noodles Practicing Medicine
 Noodles, Poodles and More!
 Noodles, Poodles and More!
 Noodly Pasta Maker
+noop prevents misuse
 noop(); pop(); map();
 Noosphere Possibilities Maximized
 Nope, prefer mopeds.

--- a/expansions.txt
+++ b/expansions.txt
@@ -640,7 +640,7 @@ Noodles Practicing Medicine
 Noodles, Poodles and More!
 Noodles, Poodles and More!
 Noodly Pasta Maker
-noop prevents misuse
+Noop Prevents Misuse
 noop(); pop(); map();
 Noosphere Possibilities Maximized
 Nope, prefer mopeds.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Adds a new expansion of NPM "noop prevents misuse". A sardonic remark on locking down software (or occasionally hardware) to prevent the ambiguously defined concern of "misuse".


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
