### PR TITLE
fix typo in "Pigeon"

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -174,7 +174,7 @@ Nearsighted Paramecium Multiverse
 Nearsighted Penguin March
 Nearsighted Prank Master
 Neat Paraskavedekatriaphobia's Meaning
-Neat Pidgeon Manure
+Neat Pigeon Manure
 Neat! Pickled Muskrat!
 Neatly Packaged Magic
 Neatly Packaged Manuals


### PR DESCRIPTION
### What

Changed "Neat **Pidgeon** Manure" to "Neat **Pigeon** Manure"

### Why

The word "[pidgeon](https://en.wiktionary.org/wiki/Pidgeon#English)" (an [archaic spelling of "pigeon"](https://en.wiktionary.org/wiki/pidgeon)) appears in modern times only as a proper surname (eg. "[Walter Pidgeon was a Canadian-American actor](https://en.wikipedia.org/wiki/Walter_Pidgeon).")

_Note: Here I am making the assumption that we are talking about a bird's manure and not the actor's. If the latter is the case, this entry almost certainly violates the terms of this repository, not to mention the honor of Mr. Pidegon's legacy, regardless of how neat his manure might be._