### PR TITLE
Add "Nutritious Pea Milk"

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -826,6 +826,7 @@ Nutmeg Plundering Muse
 Nutrias Punching Marmots
 Nutrient Packed Morsels
 Nutritious Pancake Mountain
+Nutritious Pea Milk
 Nutritious Polygonal Meatball
 Nutritious Pomegranate Muffins
 Nutritious Potato Munchies


### PR DESCRIPTION
An acquaintance mentioned not liking something called "Ripple Milk." One Google search later, this PR was born.
Adds "Nutritious Pea Milk," the term Ripple Foods uses to describe their vegan, non-dairy milk product, to the list of expansions.


## References
N/A
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
