### PR TITLE
Added 'Như Phở Mực' (🇻🇳viet pride wooooo 👍🍜🦑  🇻🇳)

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -406,6 +406,7 @@ Next Popular Module
 Next Prince Montage
 next() Packaged Middleware
 NeXTSTEP Programming Mastermind
+Như Phở Mực
 Nibble Plum Meringue
 Nibbling Pastry Monster
 Nibbling Perfect Macaroni


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


Như -> translates to "like" 👍 
Phở -> the Vietnamese soup everyone loves 🍜 
Mực -> Squid 🦑 

The literal translation is "like squid pho".
