### PR TITLE
Remove Duplicates when Building

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,12 +14,14 @@ var list = fs
     return a.toLowerCase().localeCompare(b.toLowerCase());
   })
 
-fs.writeFileSync(outfile_json, JSON.stringify(list, null, 2))
+var distinct = [...new Set(list)]
 
-fs.writeFileSync(outfile_txt, list.reduce(
+fs.writeFileSync(outfile_json, JSON.stringify(distinct, null, 2))
+
+fs.writeFileSync(outfile_txt, distinct.reduce(
   function(p, c){
     return p + c + '\n'
-  }, list.shift() + '\n')
+  }, distinct.shift() + '\n')
 )
 // reappend the instructions
 fs.appendFileSync(


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Minor change which will in future remove duplicate entries from the expansions.txt file.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #3265
> That adds checking for duplicates in the tests, while this automatically removes duplicates in the src.

Related to #2794
> Hoping to prevent things like this from happening again, especially because of the number of PRs looking to fix it. ^-^'