### PR TITLE
Remove duplicate entries dynamically

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,6 +14,7 @@ var list = fs
     return a.toLowerCase().localeCompare(b.toLowerCase());
   })
 
+list = list.filter(function(item,pos) { return list.indexOf(item) === pos })
 fs.writeFileSync(outfile_json, JSON.stringify(list, null, 2))
 
 fs.writeFileSync(outfile_txt, list.reduce(


### PR DESCRIPTION
Added a line of code which will remove duplicate entries from extension file
There are done of issues that gets created because of the duplication of NPM meanings in the extension file. This commit will fix all of those issues. This will remove all the duplicate entries that are currently present and even the duplicate entries that gets added in future.

File updated -> build.js

Fixes - #2794 ,  #2824 , #3265 , #3266 , #2255 