### PR TITLE
remove this one?

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -649,7 +649,6 @@ Noosphere Possibilities Maximized
 Nope, prefer mopeds.
 Nordic Panda Moor
 Normal People, MMM!
-Normal Polygamous Marriage
 Normal Programming Mistake
 Normally Palatable Mango
 Normally Pleasant Mixture


### PR DESCRIPTION
PR suggests removing _"Normal Polygamous Marriage"_

pairing with word normal is offensive to people with religious belief against polygamy. On a more general note, this isn't normal.

Not sure if this is minority or majority opinion.

Not sure what NPM's policy is about demographic questions like this..