### PR TITLE
Automatically Filter out duplicate expansions

### DIFF
--- a/build.js
+++ b/build.js
@@ -10,6 +10,7 @@ var list = fs
   .map(function(e) { return e.trim() })
   .filter(function(e) { return (e.length > 0) })
   .filter(function(e) { return e.charAt(0) !== '#' })
+  .filter(function(e, idx, currentList) { return currentList[idx + 1] ? currentList[idx + 1].toLowerCase() !== e.toLowerCase() : true})
   .sort(function (a, b) {
     return a.toLowerCase().localeCompare(b.toLowerCase());
   })


### PR DESCRIPTION
I noticed some duplicate expansions and thought that an automated process should be able to prevent that.

Modified the buid.js file, added an extra filter function, that takes the current expansion (e), the current expansions index (idx) and finally the current expansion list that has already been filtered twice (currentList).

In the filter it checks if there is a next item in the expansion list, if there is it compares the next expansion with the current expansion using toLowerCase and returns false if they match, which excludes the current expansion from the list but includes the next expansion. If there is no next line it returns true allowing the current expansion into the filtered list.

## References
  Related to #2794 #3656 #3381 #2824 #3265 #3266 #2255 #3266 #3265 #2888 #2577 #2468, #2367, #2356, #2255, #2201, #2115, #1956,
