### PR TITLE
Needless Pride Mitigation

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -209,6 +209,7 @@ Need Public Method
 Needful Program Management
 Needle-Pinpointing Machine
 Needless Patchouli Manufacture
+Needless Pride Mitigation
 Needlessly Postulating Minds
 Needlessly Promiscuous, Modularize!
 Needlessly Provoking Marsupials


### PR DESCRIPTION
<!-- What / Why -->
Add "Needles Pride Mitigation" to expansions.txt. 

This should account for the times when overconfident developers (we are all guilty sometimes) are needlessly brought back into reality and have their prior pride mitigated when trying to solve dependency conflicts.

